### PR TITLE
fix: make Client injectable + add mfa tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The exporter authenticates using your Garmin Connect username and password via t
 
 ### Multi-factor authentication
 
-If your Garmin account has MFA enabled, the exporter will prompt for the one-time code on stdin during the initial login:
+If your Garmin account has MFA enabled, the exporter will prompt for the one-time code on stdin during login:
 
 ```
 MFA code (check your email):

--- a/auth.go
+++ b/auth.go
@@ -84,6 +84,7 @@ type authManager struct {
 	password  string
 	logger    *slog.Logger
 	login     func(username, password string) (*garminconnect.Client, error)
+	newClient func(tokenFile string, opts ...garminconnect.Option) *garminconnect.Client
 	setClient func(*garminconnect.Client)
 	state     *authState
 	delay     time.Duration
@@ -93,8 +94,6 @@ type authManager struct {
 	now    func() time.Time
 	sleep  func(time.Duration)
 	jitter func() time.Duration
-	// mfaPrompt is called when Garmin requires multi-factor authentication.
-	mfaPrompt func() (string, error)
 }
 
 func newAuthManager(username, password, tokenFile string, logger *slog.Logger, state *authState, reauthCh <-chan struct{}, mfaPrompt func() (string, error)) *authManager {
@@ -102,7 +101,7 @@ func newAuthManager(username, password, tokenFile string, logger *slog.Logger, s
 		username:  username,
 		password:  password,
 		logger:    logger,
-		mfaPrompt: mfaPrompt,
+		newClient: garminconnect.NewClient,
 		setClient: collector.SetClient,
 		state:     state,
 		delay:     authBackoffMin,
@@ -112,11 +111,7 @@ func newAuthManager(username, password, tokenFile string, logger *slog.Logger, s
 		jitter:    func() time.Duration { return time.Duration(rand.Int63n(int64(authBackoffMin))) },
 	}
 	m.login = func(username, password string) (*garminconnect.Client, error) {
-		var opts []garminconnect.Option
-		if m.mfaPrompt != nil {
-			opts = append(opts, garminconnect.WithMFAPrompt(m.mfaPrompt))
-		}
-		garminClient := garminconnect.NewClient(tokenFile, opts...)
+		garminClient := m.newClient(tokenFile, garminconnect.WithMFAPrompt(mfaPrompt))
 		if err := garminClient.Login(username, password); err != nil {
 			return nil, err
 		}

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"testing"
 	"time"
 
@@ -10,6 +12,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
+
+type failTransport struct{}
+
+func (failTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("no network in tests")
+}
 
 func TestAuthManagerLoginFailureSchedulesRetry(t *testing.T) {
 	now := time.Unix(1000, 0)
@@ -160,6 +168,20 @@ func TestAuthManagerRunReauthOnSignal(t *testing.T) {
 	}
 	if loginCount != 2 {
 		t.Fatalf("expected 2 login calls, got %d", loginCount)
+	}
+}
+
+func TestNewAuthManagerLoginPassesMFAPrompt(t *testing.T) {
+	var capturedOpts []garminconnect.Option
+	mfaPrompt := func() (string, error) { return "123456", nil }
+	m := newAuthManager("user", "pass", "", slog.Default(), newAuthState(), nil, mfaPrompt)
+	m.newClient = func(tokenFile string, opts ...garminconnect.Option) *garminconnect.Client {
+		capturedOpts = opts
+		return garminconnect.NewClient(tokenFile, garminconnect.WithHTTPClient(&http.Client{Transport: failTransport{}}))
+	}
+	m.login("user", "pass") //login failure expected
+	if len(capturedOpts) != 1 {
+		t.Fatalf("expected 1 opt (WithMFAPrompt), got %d", len(capturedOpts))
 	}
 }
 


### PR DESCRIPTION
Remove `mfaPrompt` from `authManager` struct. Its only needed to live long enough to close over in the login func. Make `garminconnect.NewClient` injectable via a `newClient` field so the MFA opt-passing can be verified in tests without real network calls.