### PR TITLE
feat: add trace support to garmin exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,12 @@ require (
 	github.com/prometheus/exporter-toolkit v0.16.0
 	github.com/prometheus/procfs v0.20.1
 	go.opentelemetry.io/contrib/bridges/prometheus v0.69.0
+	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 )
 
@@ -38,9 +42,8 @@ require (
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.68.0 h1:8rQJvQmYltsR2L7h8Zw0Iyj8WYNNmpwikoQTZXwfVeA=
-github.com/prometheus/common v0.68.0/go.mod h1:4soH+U8yJSROk7OJ//hmTiWKsxapv6zRGgTt3keN8gQ=
 github.com/prometheus/common v0.68.1 h1:omjRRl4QP4komogpXuhfeOiisQg7xdy8VM1UY+pStaY=
 github.com/prometheus/common v0.68.1/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
 github.com/prometheus/exporter-toolkit v0.16.0 h1:xT/j7L2XKF+VJd6B4fpUw6xWabHrSmsUf6mYmFqyu0s=
@@ -86,6 +84,12 @@ go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 h1:SUp
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0/go.mod h1:ho2g4N+ane+swq5I/VBkKWnRDY4kUINH3FuqyZqX/Ug=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 h1:RuynHbfU8JUEw7DyONgkVYg2SVtsoF28y0LGIr69jgA=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0/go.mod h1:qZF+/lBs71APw8mlnEZcqZHMzqrYrsFiJOv83lX1OGo=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUYgn0OG78pN0rnNPRGX4SbokQI=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0/go.mod h1:+wnlSn0mD1ADVMe3v9Z/WIaiz6q6gL2J/ejaAmdmv80=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJlUOQzhCpzQpFETGby7EdqjI1wsd0W+6Gg1SCTU=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0/go.mod h1:fOD2Yefuxixkx3ahVNf0O/PERb6r4OlbxfATVnYvzCo=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 h1:lgh3PiVrRUWMLOVSkQicxzZll5NjF1r+AtsX1XRIHw0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0/go.mod h1:5Cnhth3m/AgOeTgE3ex12pPmiu/gGtZit03kSzx9X7s=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/barnes-c/go-garminconnect/garminconnect"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/barnes-c/garmin_exporter/collector"
 )
@@ -151,8 +154,9 @@ func (m *Manager) resetDelay() {
 // Run runs the login loop: attempts an initial login (retrying on failure),
 // then re-logs in whenever a signal arrives on reauthCh.
 func (m *Manager) Run() {
+	ctx := context.Background()
 	for {
-		delay, ok := m.attemptLogin()
+		delay, ok := m.attemptLogin(ctx)
 		if ok {
 			break
 		}
@@ -162,7 +166,7 @@ func (m *Manager) Run() {
 		m.logger.Info("re-authenticating due to stale token")
 		m.resetDelay()
 		for {
-			delay, ok := m.attemptLogin()
+			delay, ok := m.attemptLogin(ctx)
 			if ok {
 				break
 			}
@@ -191,9 +195,14 @@ func (m *Manager) TriggerReauth() {
 	}
 }
 
-func (m *Manager) attemptLogin() (time.Duration, bool) {
+func (m *Manager) attemptLogin(ctx context.Context) (time.Duration, bool) {
+	tracer := otel.Tracer("garmin_exporter/auth")
+	_, span := tracer.Start(ctx, "garmin.auth.login")
+	defer span.End()
+
 	garminClient, err := m.login(m.username, m.password)
 	if err == nil {
+		span.SetAttributes(attribute.Bool("garmin.auth.success", true))
 		m.setClient(garminClient)
 		m.state.SetLoginSuccess()
 		m.resetDelay()
@@ -202,8 +211,13 @@ func (m *Manager) attemptLogin() (time.Duration, bool) {
 		return 0, true
 	}
 
+	span.RecordError(err)
+	span.SetStatus(codes.Error, "login failed")
+	span.SetAttributes(attribute.Bool("garmin.auth.success", false))
+
 	delay := m.nextDelay()
 	nextRetry := m.now().Add(delay)
+	span.SetAttributes(attribute.String("garmin.auth.next_retry", nextRetry.Format(time.RFC3339)))
 	m.setClient(nil)
 	m.state.SetLoginFailure(nextRetry)
 	m.logger.Error("Garmin login failed", "err", err, "retry_after", delay, "next_retry", nextRetry.Unix())

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -43,7 +43,7 @@ func TestManagerLoginFailureSchedulesRetry(t *testing.T) {
 		jitter: func() time.Duration { return 0 },
 	}
 
-	delay, ok := manager.attemptLogin()
+	delay, ok := manager.attemptLogin(context.Background())
 	if ok {
 		t.Fatal("expected login attempt to fail")
 	}
@@ -84,7 +84,7 @@ func TestManagerLoginSuccessInstallsClient(t *testing.T) {
 		jitter:  func() time.Duration { return 0 },
 	}
 
-	delay, ok := manager.attemptLogin()
+	delay, ok := manager.attemptLogin(context.Background())
 	if !ok {
 		t.Fatal("expected login attempt to succeed")
 	}
@@ -120,7 +120,7 @@ func TestManagerBackoffDelayIsCapped(t *testing.T) {
 	}
 
 	for _, want := range []time.Duration{time.Hour, 2 * time.Hour, 3 * time.Hour, 3 * time.Hour} {
-		delay, ok := manager.attemptLogin()
+		delay, ok := manager.attemptLogin(context.Background())
 		if ok {
 			t.Fatal("expected login attempt to fail")
 		}
@@ -208,7 +208,7 @@ func TestManagerReadySignalsOnFirstSuccess(t *testing.T) {
 	}
 
 	// First attempt fails; Ready must not return yet.
-	if _, ok := manager.attemptLogin(); ok {
+	if _, ok := manager.attemptLogin(context.Background()); ok {
 		t.Fatal("expected first login to fail")
 	}
 	earlyCtx, earlyCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
@@ -218,7 +218,7 @@ func TestManagerReadySignalsOnFirstSuccess(t *testing.T) {
 	}
 
 	// Second attempt succeeds; Ready must return nil.
-	if _, ok := manager.attemptLogin(); !ok {
+	if _, ok := manager.attemptLogin(context.Background()); !ok {
 		t.Fatal("expected second login to succeed")
 	}
 	if err := manager.Ready(context.Background()); err != nil {
@@ -226,7 +226,7 @@ func TestManagerReadySignalsOnFirstSuccess(t *testing.T) {
 	}
 
 	// Subsequent successes must not panic (sync.Once guards the close).
-	if _, ok := manager.attemptLogin(); !ok {
+	if _, ok := manager.attemptLogin(context.Background()); !ok {
 		t.Fatal("expected third login to succeed")
 	}
 	if err := manager.Ready(context.Background()); err != nil {

--- a/internal/otlp/otlp.go
+++ b/internal/otlp/otlp.go
@@ -1,6 +1,6 @@
 // Package otlp wires the existing Prometheus registries into an OpenTelemetry
-// metrics push pipeline so the exporter can emit OTLP in addition to serving
-// /metrics.
+// metrics push pipeline and configures distributed tracing so the exporter can
+// emit OTLP in addition to serving /metrics.
 package otlp
 
 import (
@@ -10,11 +10,18 @@ import (
 	"time"
 
 	prombridge "go.opentelemetry.io/contrib/bridges/prometheus"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/version"
 )
 
 // Config configures the OTLP push pipeline.
@@ -24,34 +31,70 @@ type Config struct {
 }
 
 // Setup constructs an OTLP push pipeline that reads from the given Prometheus
-// gatherer and returns a shutdown function.
+// gatherer, sets up a TracerProvider for distributed tracing, and returns a
+// shutdown function.
 func Setup(ctx context.Context, gatherer prometheus.Gatherer, logger *slog.Logger, cfg Config) (func(context.Context) error, error) {
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName("garmin_exporter"),
+			semconv.ServiceVersion(version.Version),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating OTel resource: %w", err)
+	}
+
 	bridge := prombridge.NewMetricProducer(prombridge.WithGatherer(gatherer))
 
-	var exporter sdkmetric.Exporter
-	var err error
+	var metricExporter sdkmetric.Exporter
+	var traceExporter sdktrace.SpanExporter
 
 	switch cfg.Protocol {
 	case "grpc":
-		exporter, err = otlpmetricgrpc.New(ctx)
+		metricExporter, err = otlpmetricgrpc.New(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("creating OTLP gRPC metric exporter: %w", err)
+		}
+		traceExporter, err = otlptracegrpc.New(ctx)
 	case "http/protobuf", "http":
-		exporter, err = otlpmetrichttp.New(ctx)
+		metricExporter, err = otlpmetrichttp.New(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("creating OTLP HTTP metric exporter: %w", err)
+		}
+		traceExporter, err = otlptracehttp.New(ctx)
 	default:
 		return nil, fmt.Errorf("unsupported OTLP protocol %q, must be \"grpc\" or \"http/protobuf\"", cfg.Protocol)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("creating OTLP %s exporter: %w", cfg.Protocol, err)
+		return nil, fmt.Errorf("creating OTLP %s trace exporter: %w", cfg.Protocol, err)
 	}
 
 	reader := sdkmetric.NewPeriodicReader(
-		exporter,
+		metricExporter,
 		sdkmetric.WithProducer(bridge),
 		sdkmetric.WithInterval(cfg.Interval),
 	)
+	meterProvider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(res),
+	)
 
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tracerProvider)
 
-	logger.Info("OTLP metrics push enabled", "protocol", cfg.Protocol, "interval", cfg.Interval)
+	logger.Info("OTLP metrics and tracing enabled", "protocol", cfg.Protocol, "interval", cfg.Interval)
 
-	return provider.Shutdown, nil
+	return func(ctx context.Context) error {
+		tErr := tracerProvider.Shutdown(ctx)
+		mErr := meterProvider.Shutdown(ctx)
+		if tErr != nil {
+			return tErr
+		}
+		return mErr
+	}, nil
 }

--- a/internal/scrape/scraper.go
+++ b/internal/scrape/scraper.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 var (
@@ -164,13 +167,21 @@ func (s *Scraper) refreshOnce(ctx context.Context) {
 	start := time.Now()
 	defer func() { s.refreshDuration.Observe(time.Since(start).Seconds()) }()
 
+	tracer := otel.Tracer("garmin_exporter/scrape")
+	ctx, rootSpan := tracer.Start(ctx, "garmin.refresh")
+	defer rootSpan.End()
+
 	cols, err := s.cfg.BuildCollectors()
 	if err != nil {
+		rootSpan.RecordError(err)
+		rootSpan.SetStatus(codes.Error, "build collectors failed")
 		s.cfg.Logger.Error("build collectors", "err", err)
 		s.cfg.OnScrape(false)
 		s.refreshTotal.WithLabelValues(refreshResultFailure).Inc()
 		return
 	}
+
+	rootSpan.SetAttributes(attribute.Int("garmin.collectors.count", len(cols)))
 
 	type result struct {
 		name     string
@@ -185,12 +196,17 @@ func (s *Scraper) refreshOnce(ctx context.Context) {
 		wg.Add(1)
 		go func(name string, c prometheus.Collector) {
 			defer wg.Done()
+			_, collSpan := tracer.Start(ctx, "garmin.collect."+name)
+			defer collSpan.End()
+
 			r := result{name: name}
 			if cs, ok := c.(contextSetter); ok {
 				cs.SetContext(ctx)
 			}
 			reg := prometheus.NewRegistry()
 			if regErr := reg.Register(c); regErr != nil {
+				collSpan.RecordError(regErr)
+				collSpan.SetStatus(codes.Error, "register failed")
 				s.cfg.Logger.Error("register collector", "name", name, "err", regErr)
 				mu.Lock()
 				results = append(results, r)
@@ -207,6 +223,16 @@ func (s *Scraper) refreshOnce(ctx context.Context) {
 					r.success = false
 				}
 			}
+			if !r.success {
+				if gErr != nil {
+					collSpan.RecordError(gErr)
+				}
+				collSpan.SetStatus(codes.Error, "collect failed")
+			}
+			collSpan.SetAttributes(
+				attribute.Bool("garmin.collector.success", r.success),
+				attribute.Float64("garmin.collector.duration_seconds", r.duration.Seconds()),
+			)
 			mu.Lock()
 			results = append(results, r)
 			mu.Unlock()
@@ -247,6 +273,10 @@ func (s *Scraper) refreshOnce(ctx context.Context) {
 		s.refreshTotal.WithLabelValues(refreshResultSuccess).Inc()
 	} else {
 		s.refreshTotal.WithLabelValues(refreshResultFailure).Inc()
+	}
+	rootSpan.SetAttributes(attribute.Bool("garmin.refresh.success", anySuccess))
+	if !anySuccess {
+		rootSpan.SetStatus(codes.Error, "no collector succeeded")
 	}
 	s.cfg.Logger.Debug("refresh complete", "duration_seconds", time.Since(snap.builtAt).Seconds(), "success", anySuccess)
 }


### PR DESCRIPTION
This PR adds  OpenTelemetry trace support to the exporter. Allowing us to track any request doing on auth and each scrape cycle.
Traces can be used to generate RED metrics and setup alterting if requests fail.

---

Different topic, but while looking at  the traces I was wondering if it might be a good idea to execute all the scrapes sequentially with some throttle between each request? I assume we could then increase the overall request rate without issues.

<img width="1655" height="1271" alt="image" src="https://github.com/user-attachments/assets/8d75b7ec-b0b2-4062-8d67-6726de93f8d9" />
